### PR TITLE
Modify logging in Request subclasses

### DIFF
--- a/event_store-client-http.gemspec
+++ b/event_store-client-http.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.name = 'event_store-client-http'
   s.summary = 'HTTP Client for EventStore'
-  s.version = '0.1.3'
+  s.version = '0.1.4'
   s.authors = ['']
   s.require_paths = ['lib']
   s.files = Dir.glob('{lib}/**/*')

--- a/lib/event_store/client/http/request/get.rb
+++ b/lib/event_store/client/http/request/get.rb
@@ -8,14 +8,11 @@ module EventStore
           attr_accessor :long_poll
 
           def call(path)
-            logger.trace "Getting from #{path}"
+            logger.trace "Issuing GET (Path: #{path.inspect})"
 
             body, response = get(path)
 
-            logger.info "GET Response\nPath: #{path}\nStatus: #{response.status_code} #{response.reason_phrase}"
-            logger.debug "Got from #{path}"
-
-            logger.data "(#{body.class}) #{body}"
+            logger.debug "Issued GET (Status Line: #{response.status_line.inspect}, Body Size: #{body.size}, Path: #{path.inspect})"
 
             return body, response
           end

--- a/lib/event_store/client/http/request/post.rb
+++ b/lib/event_store/client/http/request/post.rb
@@ -8,13 +8,12 @@ module EventStore
           include Request
 
           def call(data, path, expected_version: nil)
-            logger.trace "Posting to #{path}"
+            logger.trace "Issuing POST (Path: #{path.inspect}, Expected Version: #{expected_version.inspect})"
             logger.data data
 
             response = post(data, path, expected_version)
 
-            logger.info "POST Response\nPath: #{path}\nStatus: #{response.status_code} #{response.reason_phrase.rstrip}"
-            logger.debug "Posted to #{path}"
+            logger.debug "Issued POST (Status Line: #{response.status_line.inspect}, Path: #{path.inspect})"
 
             response
           end


### PR DESCRIPTION
 * Remove the logger.info that was particularly chatty and not standard
 * Trace and debug messages align with standards
 * If you want to see the request headers/body, filter on
   ES::Client::Session at the data log level.